### PR TITLE
feat: improve AirDrop display in Finder sidebar

### DIFF
--- a/.pre-commit-hooks.nix
+++ b/.pre-commit-hooks.nix
@@ -2,7 +2,13 @@
   pre-commit-check = git-hooks.lib.${system}.run {
     src = ./.;
     hooks = {
-      rustfmt.enable = true;
+      fmt = {
+        enable = true;
+        name = "Formatting";
+        entry = "make fmt";
+        pass_filenames = false;
+        files = "\\.rs$";
+      };
 
       tests = {
         enable = true;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +182,7 @@ dependencies = [
  "core-services",
  "dirs",
  "favkit",
+ "pretty_assertions",
  "thiserror 2.0.8",
 ]
 
@@ -344,6 +351,16 @@ checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -656,7 +673,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -823,3 +840,9 @@ dependencies = [
  "linux-raw-sys",
  "rustix",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ dirs = "5.0"
 [dev-dependencies]
 favkit = { path = "." }
 cargo-llvm-cov = "0.6.14"
+pretty_assertions = "1.4.0"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }

--- a/bacon.toml
+++ b/bacon.toml
@@ -73,6 +73,7 @@ l = "job:lint"
 r = "job:run"
 t = "job:test"
 shift-t = "job:test-live"  # Live test output
+ctrl-r = "toggle-raw-output"  # Toggle raw output display
 
 # Navigation (vim-like)
 esc = "back"

--- a/code-editor-rules.md
+++ b/code-editor-rules.md
@@ -153,6 +153,8 @@ FavKit is a modern Rust library and CLI tool for managing macOS Finder favorites
 4. **Git Commits**
    Follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
    
+   When the user says "let's commit" or similar, only propose a commit message following this format - do not execute any git commands.
+
    Format: `<type>[optional scope]: <description>`
    ```
    <type>[optional scope]: <description>

--- a/code-editor-rules.md
+++ b/code-editor-rules.md
@@ -181,3 +181,25 @@ Copying Objects:
 - When storing CF objects:
   - Either retain them with `CFRetain` or create a copy
   - Must balance with `CFRelease` when no longer needed
+
+# Assistant Rules
+
+1. **Minimal Changes**: Make only the changes explicitly requested by the user. Do not perform additional refactoring, cleanup, or improvements unless specifically asked.
+
+2. **Ask First**: If you see potential improvements beyond the requested changes, ask the user first and wait for their approval before proceeding.
+
+3. **Stay Focused**: Keep changes focused on the specific task at hand. Don't get sidetracked by unrelated improvements or refactoring opportunities.
+
+4. **Document Changes**: Clearly explain what changes you're making and why they're necessary for the requested task.
+
+5. **Test Impact**: Consider and communicate how your changes might affect existing tests and functionality.
+
+6. **Preserve Style**: Follow the existing code style and patterns unless asked to change them.
+
+7. **Maintain Context**: Keep track of the conversation context and don't revert or modify changes that were already approved.
+
+8. **Verify First**: Before making changes, verify that you understand the full scope of what's being requested.
+
+9. **No Scope Creep**: If a change would require modifications beyond what was explicitly requested, ask for clarification first.
+
+10. **Respect Structure**: Don't change project structure or move files unless specifically requested.

--- a/code-editor-rules.md
+++ b/code-editor-rules.md
@@ -1,205 +1,212 @@
-# FavKit
-
-Every time you choose to apply a rule(s), explicitly state the rule(s) in the output. You can abbreviate the rule description to a single word or phrase.
+# FavKit Project Rules
 
 ## Project Context
 
-A modern Rust library and CLI tool for managing macOS Finder favorites, serving as a replacement for the abandoned `mysides` tool.
+FavKit is a modern Rust library and CLI tool for managing macOS Finder favorites, replacing the abandoned `mysides` tool.
 
-- Clean Architecture implementation in Rust
-- Outside-In TDD (London School) showcase
-- Domain-Driven Design principles application
-- Modern development practices with nix + direnv
+## Architecture
 
-## Code Style and Structure
+1. **Clean Architecture**
+   - Domain layer (`finder/`):
+     - Pure business logic and types
+     - Rich domain model (not anemic)
+     - Type-driven development
+     - Business rules encoded in types
+     - Domain invariants enforced at compile time
+   - Implementation layer (`system/`):
+     - Technical details and infrastructure
+     - Adapters for external systems
+     - Implementation details
 
-- Write idiomatic, clean Rust code following community guidelines
-- Use functional programming patterns where appropriate
-- Prefer composition over inheritance
-- Use descriptive variable names that indicate purpose
-- Structure repository files as follows:
+2. **Testing Strategy**
+   - Outside-In TDD approach:
+     1. Start with acceptance tests when possible
+     2. Use integration tests with mocks for external APIs
+     3. Work inward with unit tests
+     4. Implement minimal code to pass
+     5. Refactor without changing behavior
+   - Test Coverage:
+     - Unit tests for all modules
+     - Mocks only for outermost layer (macOS API)
+     - Thorough error case testing
+     - Prefer Result over unwrap
 
-```
-src/
-├── finder/                 # Domain layer - pure types and high-level business logic
-├── system/                 # Implementation layer
-    ├── core_foundation.rs  # Safe wrappers around Core Foundation types
-    ├── favorites/          # Safe wrapper around macOS API for favorites manipulation
-    └── macos/              # Low-level macOS API calls implementation
-tests/                      # Acceptance and integration tests
-├── mock/                   # Test doubles
-docs/                       # Project documentation
-└── adr/                    # Architecture Decision Records
-```
+3. **Project Structure**
+   ```
+   src/
+   ├── finder/                 # Domain layer
+   ├── system/                 # Implementation layer
+       ├── core_foundation.rs  # CF wrappers
+       ├── favorites/          # macOS API wrapper
+       └── macos/              # Low-level API calls
+   tests/                      # Tests
+   ├── mock/                   # Test doubles
+   docs/                       # Documentation
+   └── adr/                    # ADRs
+   ```
 
-## Tech Stack
+## AI Agent Rules
 
-- Rust (nightly toolchain)
-  - Edition 2024
-  - Components: rustc, rust-std, rust-src, rust-analyzer, rust-docs, rustfmt, cargo, clippy, llvm-tools-preview
-- [Core Foundation](https://docs.rs/core-foundation/latest/core_foundation/)
-- [Core Services](https://docs.rs/core-services/latest/core_services/)
-- [thiserror](https://docs.rs/thiserror/latest/thiserror/)
-- [dirs](https://docs.rs/dirs/latest/dirs/)
-- Development Tools:
-  - [cargo-nextest](https://github.com/nextest-rs/nextest)
-  - [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov)
-  - [bacon](https://github.com/Canop/bacon)
+1. **Rule Acknowledgment**
+   - State which rule(s) you're following in each response
+   - Can abbreviate rule descriptions to single words/phrases
 
-## Rust Usage
+2. **Change Management**
+   - Make only explicitly requested changes
+   - Stay focused on the specific task
+   - Follow existing patterns
+   - Document changes clearly
+   - Keep conversation context
+   - Don't revert approved changes
 
-- Use traits for abstraction and dependency inversion
-- Use proper error handling with Result and Option
-- Prefer functional programming style over imperative
-- Prefer method chaining over explicit loops (e.g., `iter().map().filter().collect()`)
-- Prefer standard library traits (e.g., `From`, `Into`, `AsRef`) over custom traits when possible
-- Use iterators and combinators over explicit loops
+3. **Communication**
+   - Propose improvements after requested changes
+   - Wait for user approval
+   - Provide clear examples
+   - Explain rationale
+   - Ask for clarification when in doubt
 
-## Error Handling
+4. **Architecture Review**
+   - Ensure Clean Architecture compliance
+   - Follow KISS, DRY, YAGNI, SOLID principles
+   - Verify domain isolation
+   - Check separation of concerns
+   - Review and update ADRs
 
-- Use thiserror for error definitions
-- Implement custom error types for each module
-- Provide clear error messages
-- Use Result type for fallible operations
-- Implement proper error conversion traits
+## Technical Requirements
 
-## Testing
+1. **Tech Stack**
+   ```toml
+   [toolchain]
+   rust = "nightly"
+   edition = "2024"
+   components = [
+     "rustc", "rust-std", "rust-src",
+     "rust-analyzer", "rust-docs",
+     "rustfmt", "cargo", "clippy",
+     "llvm-tools-preview"
+   ]
 
-- Write acceptance tests first (ATDD)
-- Implement unit tests for all modules
-- Use test doubles (mocks) only for the outermost layer (macos api)
-- Test error cases thoroughly
-- Prefer result type for fallible operations over unwrap
+   [dependencies]
+   core-foundation = "*"  # https://docs.rs/core-foundation/latest/core_foundation/
+   core-services = "*"    # https://docs.rs/core-services/latest/core_services/
+   thiserror = "*"       # https://docs.rs/thiserror/latest/thiserror/
+   dirs = "*"            # https://docs.rs/dirs/latest/dirs/
 
-## State Management
+   [dev-dependencies]
+   cargo-nextest = "*"   # https://github.com/nextest-rs/nextest
+   cargo-llvm-cov = "*"  # https://github.com/taiki-e/cargo-llvm-cov
+   bacon = "*"           # https://github.com/Canop/bacon
+   ```
 
-- Use immutable data structures when possible
+2. **Rust Development**
+   - Type System Usage:
+     - Express domain concepts through types
+     - Encode business rules in type system
+     - Use type-driven development
+     - Prevent invalid states at compile time
+     ```rust
+     // WRONG: Stringly-typed API
+     fn add_favorite(path: String) -> Result<(), Error>
+     
+     // RIGHT: Domain concepts in types
+     struct Target {
+         path: ValidPath,
+         kind: TargetKind,
+     }
+     ```
 
-## Syntax and Formatting
+   - Standard Library Traits:
+     ```rust
+     // WRONG: Custom conversion methods
+     fn url_to_target() -> Target
+     fn as_string() -> String
+     fn into_bytes() -> Vec<u8>
+     
+     // RIGHT: Standard library traits
+     impl From<Url> for Target
+     impl AsRef<str> for Type
+     impl Into<Vec<u8>> for Type
+     ```
 
-- Use rustfmt for consistent formatting (make fmt)
-- Follow Rust naming conventions
-- Implement proper documentation comments
-- Use clippy for code quality (make lint)
+   - Code Organization:
+     - Separate data from behavior
+     - Use traits for abstraction
+     - Prefer functional style over OOP
+     - Use Rust idioms effectively
+     - Method chaining when appropriate
+     - Iterators and combinators
 
-## Documentation
+   - Error Handling:
+     - thiserror for definitions
+     - Custom error types per module
+     - Result for fallible operations
+     - Proper error conversion traits
 
-- Maintain clear README with setup instructions
-- Document public APIs with examples
-- Keep ADRs up to date
-- Include usage examples
-- Document error conditions
+3. **Documentation**
+   - Clear README
+   - API examples
+   - Up-to-date ADRs
+   - Usage examples
+   - Error conditions
 
-## Development Workflow
+4. **Git Commits**
+   Follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
+   
+   Format: `<type>[optional scope]: <description>`
+   ```
+   <type>[optional scope]: <description>
 
-- Follow (A)TDD cycle
-- Follow semantic versioning
+   [optional body]
 
-## Git Usage
+   [optional footer(s)]
+   ```
+   Types:
+   - feat: features (correlates with MINOR in semver)
+   - fix: bug fixes (correlates with PATCH in semver)
+   - refactor: code changes that neither fix bugs nor add features
+   - docs: documentation changes
+   - chore: maintenance tasks, dependency updates, etc.
+   
+   Breaking changes can be indicated by:
+   - Adding a `!` after the type/scope: `feat!:` or `feat(api)!:`
+   - Adding `BREAKING CHANGE:` in the footer
 
-Follow the Conventional Commits specification at https://www.conventionalcommits.org/en/v1.0.0/
+   Example with breaking change:
+   ```
+   feat!: drop support for Node 6
 
-Format: `<type>[optional scope]: <description>`
+   BREAKING CHANGE: use JavaScript features not available in Node 6.
+   ```
 
-```
-<type>[optional scope]: <description>
+## Core Foundation Rules
 
-[optional body]
+1. **Overview**
+   Most memory management is handled by core-foundation and core-services crates.
+   Our wrapper in `system/core_foundation.rs` provides additional safety:
+   - Type-safe wrappers around CF types
+   - Safe handling of raw pointers
+   - Proper memory management in test doubles
 
-[optional footer(s)]
-```
+   Core Foundation Documentation:
+   - [Memory Management Guide](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/CFMemoryMgmt.html)
+   - [Object Lifecycle](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Articles/lifecycle.html)
+   - [Ownership Policy](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html)
+   - [Copy Functions](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/CopyFunctions.html)
 
-Types:
-- `feat:` new features
-- `fix:` bug fixes
-- `refactor:` code changes that neither fix bugs nor add features
-- `docs:` documentation changes
-- `chore:` maintenance tasks, dependency updates, etc.
-
-Breaking changes can be indicated by adding a `!` after the type/scope or by adding a `BREAKING CHANGE:` footer.
-
-## Security
-
-- Handle sensitive data properly
-- Implement proper error handling
-- Follow Rust security best practices
-- Use safe Rust by default
-- Document security considerations
-
-## Core Foundation Memory Management
-
-We work with Core Foundation types through two layers of abstraction:
-
-1. The [core-foundation](https://docs.rs/core-foundation/latest/core_foundation/) Rust crate, which provides safe wrappers around:
+2. **Core Foundation Types**
    - [CFType](https://docs.rs/core-foundation/latest/core_foundation/base/index.html) - base type
    - [CFString](https://docs.rs/core-foundation/latest/core_foundation/string/index.html) - string type
    - [CFArray](https://docs.rs/core-foundation/latest/core_foundation/array/index.html) - array type
    - [CFUrl](https://docs.rs/core-foundation/latest/core_foundation/url/index.html) - URL type
 
-2. Our own wrapper in `system/core_foundation.rs` which provides:
-   - `CFRef<T>` - Type-safe wrapper around Core Foundation types
-   - `RawRef<T>` - Safe wrapper around non-null raw pointers
-   - Null pointer safety checks
-   - Type-safe conversions
-
-Memory Management References:
-- [Memory Management Programming Guide](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/CFMemoryMgmt.html)
-- [Object Lifecycle Management](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Articles/lifecycle.html)
-- [Ownership Policy](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html)
-- [Copy Functions](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/CopyFunctions.html)
-
-Rules:
-
-Reference Counting:
-- Every CF object has a reference count
-- `CFRetain` increments the reference count
-- `CFRelease` decrements the reference count
-- When reference count reaches 0, the object is deallocated
-
-Ownership Rules:
-- Functions with these words in their names give you ownership:
-  - `Create` (reference count = 1)
-  - `Copy` (reference count = 1)
-  - `Retain` (increments reference count)
-- Functions without these words do not give you ownership:
-  - `Get`
-  - `Find`
-  - `Register`
-
-Memory Management:
-- If you own an object, you MUST call `CFRelease` exactly once
-- If you don't own an object but need to keep it:
-  - Call `CFRetain` to claim ownership
-  - Later call `CFRelease` when done
-- Never call `CFRelease` on an object you don't own
-- Never access a CF object after releasing it
-
-Copying Objects:
-- For compound objects (collections):
-  - `CreateCopy` performs shallow copy (only container is copied)
-  - Deep copy must be done manually if needed
-- When storing CF objects:
-  - Either retain them with `CFRetain` or create a copy
-  - Must balance with `CFRelease` when no longer needed
-
-# Assistant Rules
-
-1. **Minimal Changes**: Make only the changes explicitly requested by the user. Do not perform additional refactoring, cleanup, or improvements unless specifically asked.
-
-2. **Ask First**: If you see potential improvements beyond the requested changes, ask the user first and wait for their approval before proceeding.
-
-3. **Stay Focused**: Keep changes focused on the specific task at hand. Don't get sidetracked by unrelated improvements or refactoring opportunities.
-
-4. **Document Changes**: Clearly explain what changes you're making and why they're necessary for the requested task.
-
-5. **Test Impact**: Consider and communicate how your changes might affect existing tests and functionality.
-
-6. **Preserve Style**: Follow the existing code style and patterns unless asked to change them.
-
-7. **Maintain Context**: Keep track of the conversation context and don't revert or modify changes that were already approved.
-
-8. **Verify First**: Before making changes, verify that you understand the full scope of what's being requested.
-
-9. **No Scope Creep**: If a change would require modifications beyond what was explicitly requested, ask for clarification first.
-
-10. **Respect Structure**: Don't change project structure or move files unless specifically requested.
+3. **Memory Management in Mocks**
+   When working directly with CF types:
+   - Track owned objects in mock structures
+   - Balance CFRetain/CFRelease calls
+   - Never access released objects
+   - Be extra careful with raw pointers
+   - Retain objects you need to keep
+   - Release when mock is dropped
+   - Never release objects you don't own
+   - Prevent dangling pointers

--- a/src/finder/display_name.rs
+++ b/src/finder/display_name.rs
@@ -1,12 +1,32 @@
-pub type DisplayName = Option<String>;
+#[derive(Debug, PartialEq)]
+pub enum DisplayName {
+    AirDrop,
+    Custom(String),
+}
+
+impl From<Option<String>> for DisplayName {
+    fn from(name: Option<String>) -> Self {
+        name.map(DisplayName::Custom)
+            .unwrap_or(DisplayName::AirDrop)
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn should_handle_empty_display_name() {
-        let name: DisplayName = None;
-        assert!(name.is_none());
+    fn should_convert_none_to_airdrop() {
+        let name: Option<String> = None;
+        assert_eq!(DisplayName::from(name), DisplayName::AirDrop);
+    }
+
+    #[test]
+    fn should_convert_some_to_custom() {
+        let name = Some("Documents".to_string());
+        assert_eq!(
+            DisplayName::from(name),
+            DisplayName::Custom("Documents".to_string())
+        );
     }
 }

--- a/src/finder/sidebar.rs
+++ b/src/finder/sidebar.rs
@@ -1,32 +1,28 @@
 use std::fmt;
 
-use super::DisplayName;
-
 #[derive(Debug, PartialEq)]
-pub struct Target(pub String);
+pub enum Target {
+    AirDrop,
+    Custom { label: String, path: String },
+}
 
 #[derive(Debug, PartialEq)]
 pub struct SidebarItem {
-    display_name: DisplayName,
     target: Target,
 }
 
 impl SidebarItem {
-    pub fn new(display_name: DisplayName, target: Target) -> Self {
-        Self {
-            display_name,
-            target,
-        }
+    pub fn new(target: Target) -> Self {
+        Self { target }
     }
 }
 
 impl fmt::Display for SidebarItem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let name = match &self.display_name {
-            DisplayName::AirDrop => "AirDrop",
-            DisplayName::Custom(name) => name,
-        };
-        write!(f, "{} -> {}", name, self.target.0)
+        match &self.target {
+            Target::AirDrop => write!(f, "AirDrop"),
+            Target::Custom { label, path } => write!(f, "{} -> {}", label, path),
+        }
     }
 }
 
@@ -36,10 +32,10 @@ mod tests {
 
     #[test]
     fn should_create_sidebar_item_with_display_name() {
-        let item = SidebarItem::new(
-            DisplayName::Custom("Documents".to_string()),
-            Target("file:///Users/user/Documents".to_string()),
-        );
+        let item = SidebarItem::new(Target::Custom {
+            label: "Documents".to_string(),
+            path: "file:///Users/user/Documents".to_string(),
+        });
         assert_eq!(
             format!("{}", item),
             "Documents -> file:///Users/user/Documents"
@@ -48,10 +44,7 @@ mod tests {
 
     #[test]
     fn should_create_sidebar_item_with_airdrop() {
-        let item = SidebarItem::new(
-            DisplayName::AirDrop,
-            Target("nwnode://domain-AirDrop".to_string()),
-        );
-        assert_eq!(format!("{}", item), "AirDrop -> nwnode://domain-AirDrop");
+        let item = SidebarItem::new(Target::AirDrop);
+        assert_eq!(format!("{}", item), "AirDrop");
     }
 }

--- a/src/finder/sidebar.rs
+++ b/src/finder/sidebar.rs
@@ -22,10 +22,11 @@ impl SidebarItem {
 
 impl fmt::Display for SidebarItem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.display_name {
-            Some(name) => write!(f, "{} -> {}", name, self.target.0),
-            None => write!(f, "<no name> -> {}", self.target.0),
-        }
+        let name = match &self.display_name {
+            DisplayName::AirDrop => "AirDrop",
+            DisplayName::Custom(name) => name,
+        };
+        write!(f, "{} -> {}", name, self.target.0)
     }
 }
 
@@ -36,7 +37,7 @@ mod tests {
     #[test]
     fn should_create_sidebar_item_with_display_name() {
         let item = SidebarItem::new(
-            Some("Documents".to_string()),
+            DisplayName::Custom("Documents".to_string()),
             Target("file:///Users/user/Documents".to_string()),
         );
         assert_eq!(
@@ -46,8 +47,11 @@ mod tests {
     }
 
     #[test]
-    fn should_create_sidebar_item_with_null_display_name() {
-        let item = SidebarItem::new(None, Target("nwnode://domain-AirDrop".to_string()));
-        assert_eq!(format!("{}", item), "<no name> -> nwnode://domain-AirDrop");
+    fn should_create_sidebar_item_with_airdrop() {
+        let item = SidebarItem::new(
+            DisplayName::AirDrop,
+            Target("nwnode://domain-AirDrop".to_string()),
+        );
+        assert_eq!(format!("{}", item), "AirDrop -> nwnode://domain-AirDrop");
     }
 }

--- a/src/system/favorites/mod.rs
+++ b/src/system/favorites/mod.rs
@@ -68,12 +68,18 @@ impl Favorites {
     }
 
     unsafe fn convert_item(&self, item: SnapshotItem) -> Result<SidebarItem> {
-        let display_name = unsafe { self.copy_display_name(&item) }
-            .ok()
-            .map(|name| name.to_string())
-            .and_then(|name| (!name.is_empty()).then_some(name));
         let url = unsafe { self.copy_resolved_url(&item) }?;
         let target = Target(url.to_string());
+
+        let display_name = if target.0 == "nwnode://domain-AirDrop" {
+            Some("AirDrop".to_string())
+        } else {
+            unsafe { self.copy_display_name(&item) }
+                .ok()
+                .map(|name| name.to_string())
+                .and_then(|name| (!name.is_empty()).then_some(name))
+        };
+
         Ok(SidebarItem::new(display_name, target))
     }
 }

--- a/src/system/favorites/mod.rs
+++ b/src/system/favorites/mod.rs
@@ -15,7 +15,7 @@ pub use snapshot_item::SnapshotItem;
 pub use url::Url;
 
 use crate::{
-    finder::{Result, SidebarItem, Target, favorites::FavoritesApi},
+    finder::{self, Result, SidebarItem, Target, favorites::FavoritesApi},
     system::api::MacOsApi,
 };
 
@@ -72,12 +72,13 @@ impl Favorites {
         let target = Target(url.to_string());
 
         let display_name = if target.0 == "nwnode://domain-AirDrop" {
-            Some("AirDrop".to_string())
+            finder::DisplayName::AirDrop
         } else {
-            unsafe { self.copy_display_name(&item) }
+            let name = unsafe { self.copy_display_name(&item) }
                 .ok()
                 .map(|name| name.to_string())
-                .and_then(|name| (!name.is_empty()).then_some(name))
+                .and_then(|name| (!name.is_empty()).then_some(name));
+            finder::DisplayName::from(name)
         };
 
         Ok(SidebarItem::new(display_name, target))

--- a/src/system/favorites/mod.rs
+++ b/src/system/favorites/mod.rs
@@ -4,6 +4,7 @@ mod handle;
 mod snapshot;
 mod snapshot_item;
 mod url;
+mod url_mapper;
 
 use core_foundation::base::kCFAllocatorDefault;
 use core_services::{LSSharedFileListResolutionFlags, kLSSharedFileListFavoriteItems};
@@ -13,6 +14,7 @@ pub use handle::FavoritesHandle;
 pub use snapshot::Snapshot;
 pub use snapshot_item::SnapshotItem;
 pub use url::Url;
+pub use url_mapper::TargetUrl;
 
 use crate::{
     finder::{Result, SidebarItem, Target, favorites::FavoritesApi},
@@ -69,16 +71,8 @@ impl Favorites {
 
     unsafe fn convert_item(&self, item: SnapshotItem) -> Result<SidebarItem> {
         let url = unsafe { self.copy_resolved_url(&item) }?;
-        let target = if url.to_string() == "nwnode://domain-AirDrop" {
-            Target::AirDrop
-        } else {
-            let name = unsafe { self.copy_display_name(&item) }?.to_string();
-            Target::Custom {
-                label: name,
-                path: url.to_string(),
-            }
-        };
-
+        let name = unsafe { self.copy_display_name(&item) }?;
+        let target = Target::from(TargetUrl(url, name));
         Ok(SidebarItem::new(target))
     }
 }

--- a/src/system/favorites/mod.rs
+++ b/src/system/favorites/mod.rs
@@ -15,7 +15,7 @@ pub use snapshot_item::SnapshotItem;
 pub use url::Url;
 
 use crate::{
-    finder::{self, Result, SidebarItem, Target, favorites::FavoritesApi},
+    finder::{Result, SidebarItem, Target, favorites::FavoritesApi},
     system::api::MacOsApi,
 };
 
@@ -69,19 +69,17 @@ impl Favorites {
 
     unsafe fn convert_item(&self, item: SnapshotItem) -> Result<SidebarItem> {
         let url = unsafe { self.copy_resolved_url(&item) }?;
-        let target = Target(url.to_string());
-
-        let display_name = if target.0 == "nwnode://domain-AirDrop" {
-            finder::DisplayName::AirDrop
+        let target = if url.to_string() == "nwnode://domain-AirDrop" {
+            Target::AirDrop
         } else {
-            let name = unsafe { self.copy_display_name(&item) }
-                .ok()
-                .map(|name| name.to_string())
-                .and_then(|name| (!name.is_empty()).then_some(name));
-            finder::DisplayName::from(name)
+            let name = unsafe { self.copy_display_name(&item) }?.to_string();
+            Target::Custom {
+                label: name,
+                path: url.to_string(),
+            }
         };
 
-        Ok(SidebarItem::new(display_name, target))
+        Ok(SidebarItem::new(target))
     }
 }
 

--- a/src/system/favorites/url_mapper.rs
+++ b/src/system/favorites/url_mapper.rs
@@ -1,0 +1,18 @@
+use crate::{
+    finder::Target,
+    system::favorites::{DisplayName, Url},
+};
+
+pub struct TargetUrl(pub Url, pub DisplayName);
+
+impl From<TargetUrl> for Target {
+    fn from(target: TargetUrl) -> Self {
+        match target.0.to_string().as_str() {
+            "nwnode://domain-AirDrop" => Target::AirDrop,
+            path => Target::Custom {
+                label: target.1.to_string(),
+                path: path.to_string(),
+            },
+        }
+    }
+}

--- a/tests/finder.rs
+++ b/tests/finder.rs
@@ -2,6 +2,7 @@ use favkit::{
     finder::{Finder, FinderError, Result, SidebarItem, Target},
     system::favorites::FavoritesError,
 };
+use pretty_assertions::assert_eq;
 
 mod mock;
 use mock::{favorites::FavoritesBuilder, mac_os_api::MockMacOsApiBuilder};
@@ -82,7 +83,7 @@ fn should_return_favorite_with_display_name_and_url() -> Result<()> {
 fn should_handle_airdrop_item() -> Result<()> {
     // Arrange
     let expected_result = vec![SidebarItem::new(
-        None,
+        Some("AirDrop".to_string()),
         Target(constants::AIRDROP_URL.to_string()),
     )];
     let favorites = FavoritesBuilder::new()
@@ -103,7 +104,10 @@ fn should_handle_airdrop_item() -> Result<()> {
 fn should_handle_multiple_favorites() -> Result<()> {
     // Arrange
     let expected_result = vec![
-        SidebarItem::new(None, Target(constants::AIRDROP_URL.to_string())),
+        SidebarItem::new(
+            Some("AirDrop".to_string()),
+            Target(constants::AIRDROP_URL.to_string()),
+        ),
         SidebarItem::new(
             Some("Applications".to_string()),
             Target("file:///Applications/".to_string()),

--- a/tests/finder.rs
+++ b/tests/finder.rs
@@ -1,5 +1,5 @@
 use favkit::{
-    finder::{DisplayName, Finder, FinderError, Result, SidebarItem, Target},
+    finder::{Finder, FinderError, Result, SidebarItem, Target},
     system::favorites::FavoritesError,
 };
 use pretty_assertions::assert_eq;
@@ -61,10 +61,10 @@ fn should_return_empty_list_when_no_favorites() -> Result<()> {
 #[test]
 fn should_return_favorite_with_display_name_and_url() -> Result<()> {
     // Arrange
-    let expected_result = vec![SidebarItem::new(
-        DisplayName::Custom(constants::DOCUMENTS_NAME.to_string()),
-        Target(format!("file://{}", constants::DOCUMENTS_PATH)),
-    )];
+    let expected_result = vec![SidebarItem::new(Target::Custom {
+        label: constants::DOCUMENTS_NAME.to_string(),
+        path: format!("file://{}", constants::DOCUMENTS_PATH),
+    })];
     let favorites = FavoritesBuilder::new()
         .add_item(Some(constants::DOCUMENTS_NAME), constants::DOCUMENTS_PATH)
         .build();
@@ -82,10 +82,7 @@ fn should_return_favorite_with_display_name_and_url() -> Result<()> {
 #[test]
 fn should_handle_airdrop_item() -> Result<()> {
     // Arrange
-    let expected_result = vec![SidebarItem::new(
-        DisplayName::AirDrop,
-        Target(constants::AIRDROP_URL.to_string()),
-    )];
+    let expected_result = vec![SidebarItem::new(Target::AirDrop)];
     let favorites = FavoritesBuilder::new()
         .add_item(None, constants::AIRDROP_URL)
         .build();
@@ -104,18 +101,15 @@ fn should_handle_airdrop_item() -> Result<()> {
 fn should_handle_multiple_favorites() -> Result<()> {
     // Arrange
     let expected_result = vec![
-        SidebarItem::new(
-            DisplayName::AirDrop,
-            Target(constants::AIRDROP_URL.to_string()),
-        ),
-        SidebarItem::new(
-            DisplayName::Custom("Applications".to_string()),
-            Target("file:///Applications/".to_string()),
-        ),
-        SidebarItem::new(
-            DisplayName::Custom("Downloads".to_string()),
-            Target("file:///Users/user/Downloads/".to_string()),
-        ),
+        SidebarItem::new(Target::AirDrop),
+        SidebarItem::new(Target::Custom {
+            label: "Applications".to_string(),
+            path: "file:///Applications/".to_string(),
+        }),
+        SidebarItem::new(Target::Custom {
+            label: "Downloads".to_string(),
+            path: "file:///Users/user/Downloads/".to_string(),
+        }),
     ];
     let favorites = FavoritesBuilder::new()
         .add_item(None, constants::AIRDROP_URL)

--- a/tests/finder.rs
+++ b/tests/finder.rs
@@ -1,5 +1,5 @@
 use favkit::{
-    finder::{Finder, FinderError, Result, SidebarItem, Target},
+    finder::{DisplayName, Finder, FinderError, Result, SidebarItem, Target},
     system::favorites::FavoritesError,
 };
 use pretty_assertions::assert_eq;
@@ -62,7 +62,7 @@ fn should_return_empty_list_when_no_favorites() -> Result<()> {
 fn should_return_favorite_with_display_name_and_url() -> Result<()> {
     // Arrange
     let expected_result = vec![SidebarItem::new(
-        Some(constants::DOCUMENTS_NAME.to_string()),
+        DisplayName::Custom(constants::DOCUMENTS_NAME.to_string()),
         Target(format!("file://{}", constants::DOCUMENTS_PATH)),
     )];
     let favorites = FavoritesBuilder::new()
@@ -83,7 +83,7 @@ fn should_return_favorite_with_display_name_and_url() -> Result<()> {
 fn should_handle_airdrop_item() -> Result<()> {
     // Arrange
     let expected_result = vec![SidebarItem::new(
-        Some("AirDrop".to_string()),
+        DisplayName::AirDrop,
         Target(constants::AIRDROP_URL.to_string()),
     )];
     let favorites = FavoritesBuilder::new()
@@ -105,15 +105,15 @@ fn should_handle_multiple_favorites() -> Result<()> {
     // Arrange
     let expected_result = vec![
         SidebarItem::new(
-            Some("AirDrop".to_string()),
+            DisplayName::AirDrop,
             Target(constants::AIRDROP_URL.to_string()),
         ),
         SidebarItem::new(
-            Some("Applications".to_string()),
+            DisplayName::Custom("Applications".to_string()),
             Target("file:///Applications/".to_string()),
         ),
         SidebarItem::new(
-            Some("Downloads".to_string()),
+            DisplayName::Custom("Downloads".to_string()),
             Target("file:///Users/user/Downloads/".to_string()),
         ),
     ];


### PR DESCRIPTION
feat: improve AirDrop display in Finder sidebar

This PR introduces proper handling of AirDrop items in the Finder sidebar:
- Add Target enum to represent AirDrop and custom items
- Update display name handling to show "AirDrop" correctly
- Improve domain model to handle AirDrop as a first-class concept