### PR TITLE
feat: simplify target handling to use full paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,18 @@ This project is currently in alpha stage. Progress and next steps:
   - AirDrop: Shows as "AirDrop" without exposing internal URL
   - Recents: Shows as "Recents" without exposing internal URL
   - Applications: Shows as "Applications" without exposing internal URL
-
-🚧 **In Progress**:
+  - Desktop: Shows as "~/Desktop" for user's desktop folder
+  - Downloads: Shows as "~/Downloads" for user's downloads folder
 - User-friendly path formatting (show regular paths instead of raw URLs)
 
+🚧 **In Progress**:
+- Support for custom folder locations
+
 🔜 **Planned**:
-- Handle special locations:
-  - User Desktop (`file:///Users/<user>/Desktop/`)
-  - User Downloads (`file:///Users/<user>/Downloads/`)
 - Add/remove favorites
 - Command-line interface improvements
+
+- Configuration options
 
 ## Documentation
 

--- a/src/finder/sidebar.rs
+++ b/src/finder/sidebar.rs
@@ -5,8 +5,6 @@ pub enum Target {
     AirDrop,
     Recents,
     Applications,
-    Downloads,
-    Desktop,
     Custom { label: String, path: String },
 }
 
@@ -36,8 +34,6 @@ impl fmt::Display for SidebarItem {
             Target::AirDrop => write!(f, "AirDrop"),
             Target::Recents => write!(f, "Recents"),
             Target::Applications => write!(f, "Applications"),
-            Target::Downloads => write!(f, "~/Downloads"),
-            Target::Desktop => write!(f, "~/Desktop"),
             Target::Custom { label, path } => write!(f, "{} -> {}", label, path),
         }
     }
@@ -71,17 +67,5 @@ mod tests {
     fn should_create_sidebar_item_with_applications() {
         let item = SidebarItem::new(Target::Applications);
         assert_eq!(format!("{}", item), "Applications");
-    }
-
-    #[test]
-    fn should_create_sidebar_item_with_downloads() {
-        let item = SidebarItem::new(Target::Downloads);
-        assert_eq!(format!("{}", item), "~/Downloads");
-    }
-
-    #[test]
-    fn should_create_sidebar_item_with_desktop() {
-        let item = SidebarItem::new(Target::Desktop);
-        assert_eq!(format!("{}", item), "~/Desktop");
     }
 }

--- a/src/finder/sidebar.rs
+++ b/src/finder/sidebar.rs
@@ -6,6 +6,7 @@ pub enum Target {
     Recents,
     Applications,
     Downloads,
+    Desktop,
     Custom { label: String, path: String },
 }
 
@@ -27,6 +28,7 @@ impl fmt::Display for SidebarItem {
             Target::Recents => write!(f, "Recents"),
             Target::Applications => write!(f, "Applications"),
             Target::Downloads => write!(f, "~/Downloads"),
+            Target::Desktop => write!(f, "~/Desktop"),
             Target::Custom { label, path } => write!(f, "{} -> {}", label, path),
         }
     }
@@ -69,5 +71,11 @@ mod tests {
     fn should_create_sidebar_item_with_downloads() {
         let item = SidebarItem::new(Target::Downloads);
         assert_eq!(format!("{}", item), "~/Downloads");
+    }
+
+    #[test]
+    fn should_create_sidebar_item_with_desktop() {
+        let item = SidebarItem::new(Target::Desktop);
+        assert_eq!(format!("{}", item), "~/Desktop");
     }
 }

--- a/src/finder/sidebar.rs
+++ b/src/finder/sidebar.rs
@@ -10,6 +10,15 @@ pub enum Target {
     Custom { label: String, path: String },
 }
 
+impl Target {
+    pub fn custom(label: impl Into<String>, path: impl Into<String>) -> Self {
+        Self::Custom {
+            label: label.into(),
+            path: path.into(),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub struct SidebarItem {
     target: Target,
@@ -42,11 +51,8 @@ mod tests {
 
     #[test]
     fn should_create_sidebar_item_with_custom_target() {
-        let item = SidebarItem::new(Target::Custom {
-            label: "Documents".to_string(),
-            path: "/Users/user/Documents".to_string(),
-        });
-        assert_eq!(format!("{}", item), "Documents -> /Users/user/Documents");
+        let item = SidebarItem::new(Target::custom("Projects", "/Users/user/Projects"));
+        assert_eq!(format!("{}", item), "Projects -> /Users/user/Projects");
     }
 
     #[test]

--- a/src/system/favorites/item.rs
+++ b/src/system/favorites/item.rs
@@ -171,18 +171,9 @@ mod tests {
     }
 
     #[test]
-    fn should_not_recognize_deep_downloads_path() {
+    fn should_not_recognize_deep_downloads_path_as_downloads() {
         let target = Target::from(FavoriteItem::new(
-            create_url("file:///Users/user/Documents/Downloads/"),
-            create_display_name("Downloads"),
-        ));
-        assert!(matches!(target, Target::Custom { .. }));
-    }
-
-    #[test]
-    fn should_not_recognize_shallow_path() {
-        let target = Target::from(FavoriteItem::new(
-            create_url("file:///Users/Downloads/"), // Only 3 slashes
+            create_url("file:///Users/user/Projects/Downloads/"),
             create_display_name("Downloads"),
         ));
         assert!(matches!(target, Target::Custom { .. }));
@@ -198,87 +189,5 @@ mod tests {
             format!("{}", item),
             "Documents -> file:///Users/user/Documents/"
         );
-    }
-
-    #[test]
-    fn should_not_recognize_non_user_path_with_correct_depth() {
-        let target = Target::from(FavoriteItem::new(
-            create_url("file:///System/Library/Desktop/"),
-            create_display_name("Desktop"),
-        ));
-        assert!(matches!(target, Target::Custom { .. }));
-    }
-
-    #[test]
-    fn should_not_recognize_path_without_file_prefix() {
-        let target = Target::from(FavoriteItem::new(
-            create_url("smb:///Users/user/Downloads/"),
-            create_display_name("Downloads"),
-        ));
-        assert!(matches!(target, Target::Custom { .. }));
-    }
-
-    #[test]
-    fn should_not_recognize_path_with_different_prefix() {
-        let path = "http:///Users/user/Downloads/";
-        let url = MacOsUrl::from(create_url(path));
-        assert!(matches!(url, MacOsUrl::Custom(_)));
-    }
-
-    #[test]
-    fn should_not_recognize_path_with_correct_depth_but_wrong_structure() {
-        let target = Target::from(FavoriteItem::new(
-            create_url("file:///one/two/three/four/"), // Right depth but wrong structure
-            create_display_name("Downloads"),
-        ));
-        assert!(matches!(target, Target::Custom { .. }));
-    }
-    #[test]
-    fn should_not_recognize_path_with_correct_depth_and_prefix_but_wrong_ending() {
-        let target = Target::from(FavoriteItem::new(
-            create_url("file:///Users/user/WrongFolder/"), // Right depth and prefix, wrong ending
-            create_display_name("Downloads"),
-        ));
-        assert!(matches!(target, Target::Custom { .. }));
-    }
-
-    #[test]
-    fn should_not_recognize_path_with_correct_ending_but_wrong_structure() {
-        let target = Target::from(FavoriteItem::new(
-            create_url("file:///var/tmp/Downloads/"), // Right ending but wrong depth and prefix
-            create_display_name("Downloads"),
-        ));
-        assert!(matches!(target, Target::Custom { .. }));
-    }
-
-    #[test]
-    fn should_not_recognize_path_with_correct_prefix_but_wrong_structure() {
-        let target = Target::from(FavoriteItem::new(
-            create_url("file:///Users/Documents/"), // Right prefix but wrong depth and ending
-            create_display_name("Documents"),
-        ));
-        assert!(matches!(target, Target::Custom { .. }));
-    }
-
-    #[test]
-    fn should_format_custom_location() {
-        let url = "file:///Users/user/Documents/Projects/";
-        let target = Target::from(FavoriteItem::new(
-            create_url(url),
-            create_display_name("Projects"),
-        ));
-        assert_eq!(target, Target::Custom {
-            label: "Projects".to_string(),
-            path: "/Users/user/Documents/Projects".to_string(),
-        });
-    }
-
-    #[test]
-    fn should_treat_non_file_url_as_custom() {
-        let target = Target::from(FavoriteItem::new(
-            create_url("http:///Users/user/Downloads/"),
-            create_display_name("Downloads"),
-        ));
-        assert!(matches!(target, Target::Custom { .. }));
     }
 }

--- a/src/system/favorites/item.rs
+++ b/src/system/favorites/item.rs
@@ -85,10 +85,7 @@ impl From<FavoriteItem> for Target {
             MacOsUrl::Applications => Target::Applications,
             MacOsUrl::Downloads => Target::Downloads,
             MacOsUrl::Desktop => Target::Desktop,
-            MacOsUrl::Custom(path) => Target::Custom {
-                label: item.name.to_string(),
-                path,
-            },
+            MacOsUrl::Custom(path) => Target::custom(item.name.to_string(), path),
         }
     }
 }
@@ -265,14 +262,14 @@ mod tests {
 
     #[test]
     fn should_format_custom_location() {
-        let url = "file:///Users/happygopher/Documents/Projects/";
+        let url = "file:///Users/user/Documents/Projects/";
         let target = Target::from(FavoriteItem::new(
             create_url(url),
             create_display_name("Projects"),
         ));
         assert_eq!(target, Target::Custom {
             label: "Projects".to_string(),
-            path: "/Users/happygopher/Documents/Projects".to_string(),
+            path: "/Users/user/Documents/Projects".to_string(),
         });
     }
 

--- a/src/system/favorites/mod.rs
+++ b/src/system/favorites/mod.rs
@@ -1,20 +1,20 @@
 mod display_name;
 mod errors;
 mod handle;
+mod item;
 mod snapshot;
 mod snapshot_item;
 mod url;
-mod url_mapper;
 
 use core_foundation::base::kCFAllocatorDefault;
 use core_services::{LSSharedFileListResolutionFlags, kLSSharedFileListFavoriteItems};
 pub use display_name::DisplayName;
 pub use errors::FavoritesError;
 pub use handle::FavoritesHandle;
+pub use item::FavoriteItem;
 pub use snapshot::Snapshot;
 pub use snapshot_item::SnapshotItem;
 pub use url::Url;
-pub use url_mapper::TargetUrl;
 
 use crate::{
     finder::{Result, SidebarItem, Target, favorites::FavoritesApi},
@@ -72,7 +72,7 @@ impl Favorites {
     unsafe fn convert_item(&self, item: SnapshotItem) -> Result<SidebarItem> {
         let url = unsafe { self.copy_resolved_url(&item) }?;
         let name = unsafe { self.copy_display_name(&item) }?;
-        let target = Target::from(TargetUrl(url, name));
+        let target = Target::from(FavoriteItem::new(url, name));
         Ok(SidebarItem::new(target))
     }
 }

--- a/src/system/favorites/url_mapper.rs
+++ b/src/system/favorites/url_mapper.rs
@@ -16,6 +16,13 @@ fn is_downloads_url(url: &str) -> bool {
         && url_path.starts_with("/Users/")
 }
 
+fn is_desktop_url(url: &str) -> bool {
+    let url_path = url.strip_prefix("file://").unwrap_or(url);
+    url_path.matches('/').count() == 4
+        && url_path.ends_with("/Desktop/")
+        && url_path.starts_with("/Users/")
+}
+
 impl From<TargetUrl> for Target {
     fn from(target: TargetUrl) -> Self {
         let url = target.0.to_string();
@@ -25,6 +32,7 @@ impl From<TargetUrl> for Target {
             RECENTS_URL => Target::Recents,
             APPLICATIONS_URL => Target::Applications,
             path if is_downloads_url(path) => Target::Downloads,
+            path if is_desktop_url(path) => Target::Desktop,
             path => Target::Custom {
                 label: target.1.to_string(),
                 path: path.to_string(),
@@ -102,5 +110,14 @@ mod tests {
             label: "Documents".to_string(),
             path: "file:///Users/user/Documents/".to_string(),
         });
+    }
+
+    #[test]
+    fn should_convert_desktop_url() {
+        let target = Target::from(TargetUrl(
+            create_url("file:///Users/user/Desktop/"),
+            create_display_name("Desktop"),
+        ));
+        assert_eq!(target, Target::Desktop);
     }
 }

--- a/tests/finder.rs
+++ b/tests/finder.rs
@@ -12,6 +12,7 @@ mod constants {
     pub const RECENTS_LABEL: &str = "Recents";
     pub const APPLICATIONS_LABEL: &str = "Applications";
     pub const DOWNLOADS_LABEL: &str = "Downloads";
+    pub const DESKTOP_LABEL: &str = "Desktop";
     pub const DOCUMENTS_LABEL: &str = "Documents";
 
     // URLs
@@ -19,6 +20,7 @@ mod constants {
     pub const RECENTS_URL: &str = "file:///System/Library/CoreServices/Finder.app/Contents/Resources/MyLibraries/myDocuments.cannedSearch/";
     pub const APPLICATIONS_URL: &str = "file:///Applications/";
     pub const DOWNLOADS_URL: &str = "file:///Users/user/Downloads/";
+    pub const DESKTOP_URL: &str = "file:///Users/user/Desktop/";
     pub const DOCUMENTS_URL: &str = "file:///Users/user/Documents/";
 }
 
@@ -178,6 +180,24 @@ fn should_handle_multiple_favorites() -> Result<()> {
             constants::APPLICATIONS_URL,
         )
         .add_item(Some(constants::DOWNLOADS_LABEL), constants::DOWNLOADS_URL)
+        .build();
+    let mock_api = MockMacOsApiBuilder::new().with_favorites(favorites).build();
+    let finder = Finder::new(mock_api);
+
+    // Act
+    let result = finder.get_favorites_list()?;
+
+    // Assert
+    assert_eq!(result, expected_result);
+    Ok(())
+}
+
+#[test]
+fn should_handle_desktop_item() -> Result<()> {
+    // Arrange
+    let expected_result = vec![SidebarItem::new(Target::Desktop)];
+    let favorites = FavoritesBuilder::new()
+        .add_item(Some(constants::DESKTOP_LABEL), constants::DESKTOP_URL)
         .build();
     let mock_api = MockMacOsApiBuilder::new().with_favorites(favorites).build();
     let finder = Finder::new(mock_api);

--- a/tests/finder.rs
+++ b/tests/finder.rs
@@ -19,14 +19,6 @@ mod constants {
     pub const APPLICATIONS_LABEL: &str = "Applications";
     pub const APPLICATIONS_URL: &str = "file:///Applications/";
 
-    // Desktop
-    pub const DESKTOP_LABEL: &str = "Desktop";
-    pub const DESKTOP_URL: &str = "file:///Users/user/Desktop/";
-
-    // Downloads
-    pub const DOWNLOADS_LABEL: &str = "Downloads";
-    pub const DOWNLOADS_URL: &str = "file:///Users/user/Downloads/";
-
     // Projects
     pub const PROJECTS_LABEL: &str = "Projects";
     pub const PROJECTS_PATH: &str = "/Users/user/Projects";
@@ -136,31 +128,11 @@ fn should_handle_applications_item() -> Result<()> {
 }
 
 #[test]
-fn should_handle_downloads_item() -> Result<()> {
-    // Arrange
-    let expected_result = vec![SidebarItem::new(Target::Downloads)];
-    let favorites = FavoritesBuilder::new()
-        .add_item(Some(constants::DOWNLOADS_LABEL), constants::DOWNLOADS_URL)
-        .build();
-    let mock_api = MockMacOsApiBuilder::new().with_favorites(favorites).build();
-    let finder = Finder::new(mock_api);
-
-    // Act
-    let result = finder.get_favorites_list()?;
-
-    // Assert
-    assert_eq!(result, expected_result);
-    Ok(())
-}
-
-#[test]
 fn should_handle_multiple_favorites() -> Result<()> {
     // Arrange
     let expected_result = vec![
         SidebarItem::new(Target::AirDrop),
         SidebarItem::new(Target::Applications),
-        SidebarItem::new(Target::Downloads),
-        SidebarItem::new(Target::Desktop),
         SidebarItem::new(Target::Custom {
             label: constants::PROJECTS_LABEL.to_string(),
             path: constants::PROJECTS_PATH.to_string(),
@@ -172,27 +144,7 @@ fn should_handle_multiple_favorites() -> Result<()> {
             Some(constants::APPLICATIONS_LABEL),
             constants::APPLICATIONS_URL,
         )
-        .add_item(Some(constants::DOWNLOADS_LABEL), constants::DOWNLOADS_URL)
-        .add_item(Some(constants::DESKTOP_LABEL), constants::DESKTOP_URL)
         .add_item(Some(constants::PROJECTS_LABEL), constants::PROJECTS_URL)
-        .build();
-    let mock_api = MockMacOsApiBuilder::new().with_favorites(favorites).build();
-    let finder = Finder::new(mock_api);
-
-    // Act
-    let result = finder.get_favorites_list()?;
-
-    // Assert
-    assert_eq!(result, expected_result);
-    Ok(())
-}
-
-#[test]
-fn should_handle_desktop_item() -> Result<()> {
-    // Arrange
-    let expected_result = vec![SidebarItem::new(Target::Desktop)];
-    let favorites = FavoritesBuilder::new()
-        .add_item(Some(constants::DESKTOP_LABEL), constants::DESKTOP_URL)
         .build();
     let mock_api = MockMacOsApiBuilder::new().with_favorites(favorites).build();
     let finder = Finder::new(mock_api);

--- a/tests/finder.rs
+++ b/tests/finder.rs
@@ -8,20 +8,29 @@ mod mock;
 use mock::{favorites::FavoritesBuilder, mac_os_api::MockMacOsApiBuilder};
 
 mod constants {
-    // Display Labels
-    pub const RECENTS_LABEL: &str = "Recents";
-    pub const APPLICATIONS_LABEL: &str = "Applications";
-    pub const DOWNLOADS_LABEL: &str = "Downloads";
-    pub const DESKTOP_LABEL: &str = "Desktop";
-    pub const DOCUMENTS_LABEL: &str = "Documents";
-
-    // URLs
+    // AirDrop
     pub const AIRDROP_URL: &str = "nwnode://domain-AirDrop";
+
+    // Recents
+    pub const RECENTS_LABEL: &str = "Recents";
     pub const RECENTS_URL: &str = "file:///System/Library/CoreServices/Finder.app/Contents/Resources/MyLibraries/myDocuments.cannedSearch/";
+
+    // Applications
+    pub const APPLICATIONS_LABEL: &str = "Applications";
     pub const APPLICATIONS_URL: &str = "file:///Applications/";
-    pub const DOWNLOADS_URL: &str = "file:///Users/user/Downloads/";
+
+    // Desktop
+    pub const DESKTOP_LABEL: &str = "Desktop";
     pub const DESKTOP_URL: &str = "file:///Users/user/Desktop/";
-    pub const DOCUMENTS_URL: &str = "file:///Users/user/Documents/";
+
+    // Downloads
+    pub const DOWNLOADS_LABEL: &str = "Downloads";
+    pub const DOWNLOADS_URL: &str = "file:///Users/user/Downloads/";
+
+    // Projects
+    pub const PROJECTS_LABEL: &str = "Projects";
+    pub const PROJECTS_PATH: &str = "/Users/user/Projects";
+    pub const PROJECTS_URL: &str = "file:///Users/user/Projects/";
 }
 
 #[test]
@@ -59,27 +68,6 @@ fn should_return_empty_list_when_no_favorites() -> Result<()> {
     // Arrange
     let expected_result: Vec<SidebarItem> = vec![];
     let mock_api = MockMacOsApiBuilder::new().build();
-    let finder = Finder::new(mock_api);
-
-    // Act
-    let result = finder.get_favorites_list()?;
-
-    // Assert
-    assert_eq!(result, expected_result);
-    Ok(())
-}
-
-#[test]
-fn should_return_favorite_with_display_name_and_url() -> Result<()> {
-    // Arrange
-    let expected_result = vec![SidebarItem::new(Target::Custom {
-        label: constants::DOCUMENTS_LABEL.to_string(),
-        path: constants::DOCUMENTS_URL.to_string(),
-    })];
-    let favorites = FavoritesBuilder::new()
-        .add_item(Some(constants::DOCUMENTS_LABEL), constants::DOCUMENTS_URL)
-        .build();
-    let mock_api = MockMacOsApiBuilder::new().with_favorites(favorites).build();
     let finder = Finder::new(mock_api);
 
     // Act
@@ -172,6 +160,11 @@ fn should_handle_multiple_favorites() -> Result<()> {
         SidebarItem::new(Target::AirDrop),
         SidebarItem::new(Target::Applications),
         SidebarItem::new(Target::Downloads),
+        SidebarItem::new(Target::Desktop),
+        SidebarItem::new(Target::Custom {
+            label: constants::PROJECTS_LABEL.to_string(),
+            path: constants::PROJECTS_PATH.to_string(),
+        }),
     ];
     let favorites = FavoritesBuilder::new()
         .add_item(None, constants::AIRDROP_URL)
@@ -180,6 +173,8 @@ fn should_handle_multiple_favorites() -> Result<()> {
             constants::APPLICATIONS_URL,
         )
         .add_item(Some(constants::DOWNLOADS_LABEL), constants::DOWNLOADS_URL)
+        .add_item(Some(constants::DESKTOP_LABEL), constants::DESKTOP_URL)
+        .add_item(Some(constants::PROJECTS_LABEL), constants::PROJECTS_URL)
         .build();
     let mock_api = MockMacOsApiBuilder::new().with_favorites(favorites).build();
     let finder = Finder::new(mock_api);
@@ -198,6 +193,28 @@ fn should_handle_desktop_item() -> Result<()> {
     let expected_result = vec![SidebarItem::new(Target::Desktop)];
     let favorites = FavoritesBuilder::new()
         .add_item(Some(constants::DESKTOP_LABEL), constants::DESKTOP_URL)
+        .build();
+    let mock_api = MockMacOsApiBuilder::new().with_favorites(favorites).build();
+    let finder = Finder::new(mock_api);
+
+    // Act
+    let result = finder.get_favorites_list()?;
+
+    // Assert
+    assert_eq!(result, expected_result);
+    Ok(())
+}
+
+#[test]
+fn should_handle_custom_location() -> Result<()> {
+    // Arrange
+    let expected_result = vec![SidebarItem::new(Target::Custom {
+        label: constants::PROJECTS_LABEL.to_string(),
+        path: constants::PROJECTS_PATH.to_string(),
+    })];
+
+    let favorites = FavoritesBuilder::new()
+        .add_item(Some(constants::PROJECTS_LABEL), constants::PROJECTS_URL)
         .build();
     let mock_api = MockMacOsApiBuilder::new().with_favorites(favorites).build();
     let finder = Finder::new(mock_api);


### PR DESCRIPTION
feat!: simplify target handling to use full paths

This PR simplifies how FavKit handles Finder favorites by treating all user directory items as custom locations with full paths.

BREAKING CHANGE: Desktop and Downloads are now handled as custom locations with full paths instead of special targets with ~ notation.